### PR TITLE
Use 'mattn/go-colorable' to draw text with color on Windows

### DIFF
--- a/pine.go
+++ b/pine.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/logrusorgru/aurora"
+	"github.com/mattn/go-colorable"
 )
 
 type msgType int
@@ -63,9 +64,11 @@ func (p *PineWriter) WithExtra(extra string) *PineExtraWriter {
 	}
 }
 
+var stdout = colorable.NewColorableStdout()
+
 var pine = &Pine{
 	timeProvider:   func() time.Time { return time.Now() },
-	outputProvider: func(msg string) { fmt.Print(msg) },
+	outputProvider: func(msg string) { fmt.Fprint(stdout, msg) },
 }
 
 func ttyFormatProvider(at time.Time, t msgType, module string, extra *string, msg string, params ...interface{}) string {


### PR DESCRIPTION
ANSI Escape sequence are ignored by terminal of Windows.

![image](https://user-images.githubusercontent.com/3752189/46172543-ba5d3900-c2de-11e8-8e8a-f9332284a393.png)

So I modified to use the emulation library `"github.com/mattn/go-colorable"` 

![image](https://user-images.githubusercontent.com/3752189/46172747-42434300-c2df-11e8-9efb-30ff29fc8821.png)

If there are no problems, would you merge ?
